### PR TITLE
Loading indicator centering

### DIFF
--- a/app/src/main/kotlin/des/c5inco/pokedexer/ui/items/ItemsScreen.kt
+++ b/app/src/main/kotlin/des/c5inco/pokedexer/ui/items/ItemsScreen.kt
@@ -1,6 +1,7 @@
 package des.c5inco.pokedexer.ui.items
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -29,6 +30,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -104,7 +106,12 @@ fun ItemsScreen(
                     )
                 }
                 is ItemsListUiState.Loading -> {
-                    CircularProgressIndicator()
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/des/c5inco/pokedexer/ui/moves/MovesListScreen.kt
+++ b/app/src/main/kotlin/des/c5inco/pokedexer/ui/moves/MovesListScreen.kt
@@ -102,7 +102,12 @@ fun MovesListScreen(
                     MovesList(moves = s.moves)
                 }
                 is MovesListUiState.Loading -> {
-                    CircularProgressIndicator()
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
                 }
             }
         }


### PR DESCRIPTION
Center loading indicators on the Moves and Item screens.

---
Linear Issue: [C5-54](https://linear.app/c5inco/issue/C5-54/center-loading-indicators-on-moves-and-item-screen)

<a href="https://cursor.com/background-agent?bcId=bc-b92bf323-1bf4-4ed3-9d38-337860f5b297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b92bf323-1bf4-4ed3-9d38-337860f5b297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

