### PR TITLE
PokeAPI graphql upgrade

### DIFF
--- a/app/src/main/kotlin/des/c5inco/pokedexer/di/ApplicationGraph.kt
+++ b/app/src/main/kotlin/des/c5inco/pokedexer/di/ApplicationGraph.kt
@@ -81,7 +81,7 @@ interface ApplicationModule {
     @SingleIn(AppScope::class)
     fun provideApolloClient(): ApolloClient {
         return ApolloClient.Builder()
-            .serverUrl("https://beta.pokeapi.co/graphql/v1beta")
+            .serverUrl("https://beta.pokeapi.co/graphql/v1beta2")
             .build()
     }
 


### PR DESCRIPTION
Upgrade PokeAPI GraphQL endpoint to v1beta2.

---
Linear Issue: [C5-52](https://linear.app/c5inco/issue/C5-52/upgrade-pokeapi-graphql-endpoint)

<a href="https://cursor.com/background-agent?bcId=bc-16f3177b-8812-4d82-a09d-7b8088051c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16f3177b-8812-4d82-a09d-7b8088051c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

