### PR TITLE
Pokemon loading animation polish

### DIFF
--- a/app/src/main/kotlin/des/c5inco/pokedexer/ui/common/LoadingSpinner.kt
+++ b/app/src/main/kotlin/des/c5inco/pokedexer/ui/common/LoadingSpinner.kt
@@ -1,0 +1,54 @@
+package des.c5inco.pokedexer.ui.common
+
+import android.os.Build
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.ImageLoader
+import coil.compose.rememberAsyncImagePainter
+import coil.decode.GifDecoder
+import coil.decode.ImageDecoderDecoder
+import coil.request.ImageRequest
+import des.c5inco.pokedexer.R
+
+/**
+ * A loading spinner component that displays an animated Pikachu GIF.
+ * This component is used consistently across the app when loading data from the network.
+ */
+@Composable
+fun LoadingSpinner(
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    
+    val imageLoader = ImageLoader.Builder(context)
+        .components {
+            if (Build.VERSION.SDK_INT >= 28) {
+                add(ImageDecoderDecoder.Factory())
+            } else {
+                add(GifDecoder.Factory())
+            }
+        }
+        .build()
+    
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(
+                model = ImageRequest.Builder(context)
+                    .data(R.drawable.pika_loader)
+                    .build(),
+                imageLoader = imageLoader
+            ),
+            contentDescription = "Loading",
+            modifier = Modifier.size(120.dp)
+        )
+    }
+}

--- a/app/src/main/kotlin/des/c5inco/pokedexer/ui/items/ItemsScreen.kt
+++ b/app/src/main/kotlin/des/c5inco/pokedexer/ui/items/ItemsScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,6 +38,7 @@ import des.c5inco.pokedexer.R
 import des.c5inco.pokedexer.data.items.SampleItems
 import des.c5inco.pokedexer.model.Item
 import des.c5inco.pokedexer.ui.common.ItemImage
+import des.c5inco.pokedexer.ui.common.LoadingSpinner
 import des.c5inco.pokedexer.ui.theme.AppTheme
 
 @Composable
@@ -104,7 +104,11 @@ fun ItemsScreen(
                     )
                 }
                 is ItemsListUiState.Loading -> {
-                    CircularProgressIndicator()
+                    LoadingSpinner(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .padding(vertical = 24.dp)
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/des/c5inco/pokedexer/ui/moves/MovesListScreen.kt
+++ b/app/src/main/kotlin/des/c5inco/pokedexer/ui/moves/MovesListScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -46,6 +45,7 @@ import des.c5inco.pokedexer.R
 import des.c5inco.pokedexer.data.moves.SampleMoves
 import des.c5inco.pokedexer.model.Move
 import des.c5inco.pokedexer.ui.common.CategoryIcon
+import des.c5inco.pokedexer.ui.common.LoadingSpinner
 import des.c5inco.pokedexer.ui.common.TypeLabel
 import des.c5inco.pokedexer.ui.common.TypeLabelMetrics.Companion.MEDIUM
 import des.c5inco.pokedexer.ui.theme.AppTheme
@@ -102,7 +102,11 @@ fun MovesListScreen(
                     MovesList(moves = s.moves)
                 }
                 is MovesListUiState.Loading -> {
-                    CircularProgressIndicator()
+                    LoadingSpinner(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .padding(vertical = 24.dp)
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/des/c5inco/pokedexer/ui/pokedex/PokedexScreen.kt
+++ b/app/src/main/kotlin/des/c5inco/pokedexer/ui/pokedex/PokedexScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FloatingActionButton
@@ -81,6 +80,7 @@ import des.c5inco.pokedexer.data.pokemon.SamplePokemonData
 import des.c5inco.pokedexer.model.Generation
 import des.c5inco.pokedexer.model.Pokemon
 import des.c5inco.pokedexer.model.Type
+import des.c5inco.pokedexer.ui.common.LoadingSpinner
 import des.c5inco.pokedexer.ui.common.Pokeball
 import des.c5inco.pokedexer.ui.common.mapTypeToIcon
 import des.c5inco.pokedexer.ui.theme.AppTheme
@@ -205,11 +205,9 @@ fun PokedexScreen(
             ) {
                 when (state) {
                     is PokedexUiState.Loading -> {
-                        CircularProgressIndicator(
-                            color = MaterialTheme.colorScheme.primary,
+                        LoadingSpinner(
                             modifier = Modifier
                                 .align(Alignment.CenterHorizontally)
-                                .size(48.dp)
                                 .padding(vertical = 24.dp)
                         )
                     }


### PR DESCRIPTION
Replace generic `CircularProgressIndicator` with a custom `LoadingSpinner` using an animated Pikachu GIF to provide a consistent and polished loading experience.

---
Linear Issue: [C5-53](https://linear.app/c5inco/issue/C5-53/polish-loading-animations-when-hitting-network-for-pokemon-loading)

<a href="https://cursor.com/background-agent?bcId=bc-81d9dde1-48da-49cd-9a76-0a911931b5fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81d9dde1-48da-49cd-9a76-0a911931b5fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

